### PR TITLE
AOT-ify build and minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ finally right around the corner, all you need is this small example to get start
 
 The purpose of this example application is to show packaging capabilities of cljfx and
 jpackage, to keep it simple some build steps where left out:
-- startup time can be improved significantly by AOT-compiling clojure code;
 - application package size can be reduced: you can use `jlink` to minify the JDK, and if 
   your application does not need to use webkit (which is used in this example), you can
   exclude cljfx's dependency on javafx-web.
@@ -38,7 +37,13 @@ window.
 
 The build process is 2-step:
 1. Assemble an uberjar. Here it's done using Sean Corfield's 
-[depstar](https://github.com/seancorfield/depstar) library with `clj -A:uberjar` alias.
+[depstar](https://github.com/seancorfield/depstar) library:
+   - `clj -Spom`
+   - `clj -X:uberjar`
+
+The built uberjar will include AOT-compiled code and can be executed via 
+`java -jar dist/hn.jar`, but we will use `jpackage` to build OS distributions:
+
 2. Use `jpackage` with common options described in [jpackage/common](jpackage/common) and 
 platform-specific options having their own files: [jpackage/linux](jpackage/linux), 
 [jpackage/mac](jpackage/mac) and [jpackage/windows](jpackage/windows). For example, if you 

--- a/build/uberjar/build.clj
+++ b/build/uberjar/build.clj
@@ -1,0 +1,12 @@
+(ns uberjar.build
+  (:require [hf.depstar.uberjar])
+  (:import (javafx.application Platform)))
+
+;; see https://github.com/cljfx/cljfx#aot-compilation-is-complicated
+
+(defn run
+  [& args]
+  (try
+    (apply hf.depstar.uberjar/run args)
+    (finally
+      (Platform/exit))))

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,11 @@
-{:deps {cljfx {:mvn/version "1.6.7"}
+{:deps {cljfx/cljfx {:mvn/version "1.6.7"}
         cljfx/css {:mvn/version "1.1.0"}
-        clj-http {:mvn/version "3.9.1"}
+        clj-http/clj-http {:mvn/version "3.9.1"}
         metosin/jsonista {:mvn/version "0.2.5"}
-        crouton {:mvn/version "0.1.2"}}
- :aliases {:uberjar {:extra-deps {seancorfield/depstar {:mvn/version "0.5.2"}}
-                     :main-opts ["-m" "hf.depstar.uberjar" "dist/hn.jar"]}}}
+        crouton/crouton {:mvn/version "0.1.2"}}
+ :aliases {:uberjar {:extra-deps {seancorfield/depstar {:mvn/version "1.1.136"}}
+                     :replace-paths ["src" "build"]
+                     :exec-fn uberjar.build/run
+                     :exec-args {:jar "dist/hn.jar"
+                                 :aot true
+                                 :main-class "hn.core"}}}}

--- a/src/hn/core.clj
+++ b/src/hn/core.clj
@@ -4,7 +4,8 @@
             [hn.event :as event]
             [hn.view :as view])
   (:import [javafx.application Platform]
-           [java.util.concurrent Executors ThreadFactory]))
+           [java.util.concurrent Executors ThreadFactory])
+  (:gen-class))
 
 (defn http-effect [v dispatch!]
   (try
@@ -23,7 +24,7 @@
   (let [*counter (atom 0)
         factory (reify ThreadFactory
                   (newThread [_ runnable]
-                    (doto (Thread. runnable (str "reveal-agent-pool-" (swap! *counter inc)))
+                    (doto (Thread. runnable (str "clfjx-hn-agent-pool-" (swap! *counter inc)))
                       (.setDaemon true))))]
     (Executors/newCachedThreadPool factory)))
 

--- a/src/hn/view.clj
+++ b/src/hn/view.clj
@@ -53,6 +53,7 @@
               "-comment" {"-cell" {:-fx-padding [small-spacing default-spacing]}}
               "-stories" {"-item" {:-fx-spacing small-spacing}
                           "-cell" {:-fx-padding [small-spacing default-spacing]}}}
+       ".error" {:-fx-text-fill :red}
        ".list-cell:empty" {:-fx-background-color :transparent}
        ".scroll-bar" {:-fx-background-color :transparent
                       ":vertical" {"> .increment-button > .increment-arrow"
@@ -115,7 +116,7 @@
       :cell-factory [:setter (fx.lifecycle/detached-prop-map fx.list-cell/props)
                      :coerce create-cell-factory])))
 
-(defn stories [{:keys [stories items]}]
+(defn stories [{:keys [stories items error]}]
   {:fx/type :v-box
    :children
    [{:fx/type :h-box
@@ -126,7 +127,10 @@
                  :text "⟲"}
                 {:fx/type :label
                  :style-class "hn-title"
-                 :text "Hacker News"}]}
+                 :text "Hacker News"}
+                {:fx/type :label
+                 :style-class "error"
+                 :text error}]}
     {:fx/type ext-with-list-cell-factory
      :v-box/vgrow :always
      :props


### PR DESCRIPTION
@vlaaad Cool project!

In evaluating `cljfx` I played around with your `cljfx/hn` reference project and ended fixing up a few things along the way. I'm happy to factor out any of these into a separate PR if you'd like any of these changes a la carte:

When I started the app, it seems it fanned out too many network requests at once and I hit the (in)famous "Too many open files" issue on my mac. 

HTTP exceptions were emitted and dispatched to event/handle but the emitted exceptions did not have an `::event/type` so there were Clojure errors about trying to do a multi-method dispatch on `nil`. To fix this, I changed the emitted exceptions to include an `::event/type ::event/exception` and I added a simple `(defmethod handle ::exception ...)` to put the recent error into the `:state` so that the view would render any such errors in red.

Incidentally I thought this might be a common issue for others so to eliminate the actual HTTP exceptions, I limited the number of stories rendered (i.e., `(take 100 ...`).

Additionally I was curious about achieving an AOT build, so I added AOT as part of the uberjar build -- it involves leveraging the `(Platform/exit)` 'trick' you describe [here](https://github.com/cljfx/cljfx#aot-compilation-is-complicated) (see `build/..`). This also required upgrading `deps.edn` to be compatible with recent `clojure` tooling as well as updating and using the latest `seancornfield/depstar` capabilities. This demo of AOT build may be interesting to other `cljfx` users!

I've tested all of this and updated the README to reflect these changes. If any of this is useful to you, great, just wanted to share these changes just in case. Thanks for the cool framework!
